### PR TITLE
add copyFile and copyFolder

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     <hr>
     <ul>
         <li v-for="f in folder.files">
-            <button v-on:click="rm(f)" class="docIcon" v-bind:class="canControl()">
+            <button v-on:click="manageResource(f)" class="docIcon" v-bind:class="canControl()">
                 <img src="./assets/document.png">
             </button>
             <button class="fileName" v-on:click.right="download(f)" v-on:click="get(f)" v-bind:title="f.label+' '+f.type">
@@ -87,17 +87,17 @@
     <div>
         <label>new folder :</label>
         <input v-model="newThing.parentFolder"
-               placeholder=" (optional) path relative to original file"
+               placeholder=" (optional) full folder URI"
         />
     </div>
     <div>
         <label>new name :</label>
         <input v-model="newThing.name"
-               placeholder=" name without path or extension"
+               placeholder=" name with extension (to same URI folder by default)"
         />
     </div>
     <p class="right-justify">
-        <button v-on:click="cpFile()">Copy file</button>
+        <button v-on:click="copy('file')">Copy file</button>
     </p>
     <hr>
 </div><!-- fileManager -->
@@ -112,11 +112,12 @@
 <button v-on:click="rm(folder)">delete this folder</button>
     <hr>
 <div>
-<label>new name</label>
-   <input v-model="newThing.name" placeholder=" (without path)">
+<label>new name/dest.</label>
+   <input v-model="newThing.name" placeholder=" (without path) except for copy Folder (url)">
 </div>
 <p class="right-justify"><button v-on:click="addThing('file')">create new file in this folder</button></p>
 <p class="right-justify"><button v-on:click="addThing('folder')">create new folder in this folder</button></p>
+<p class="right-justify"><button v-on:click="copy('folder')">recursive copy of this folder</button></p>
     <hr><hr>
 <label>upload file(s) in this folder</label>
 	<input type="file" id="upFile" name="upFile" multiple size="100" v-on:change="upload(folder)">

--- a/solid-file-client.js
+++ b/solid-file-client.js
@@ -283,7 +283,7 @@ this.processFolder = function(graph,url,content,callback){
         var stats = self.getStats(graph,url)
         var fullname = url.replace( /\/$/,'')
         var name = fullname.replace( /.*\//,'')
-        var parent = fullname.replace(name,'')
+        var parent = fullName.substr(0, fullname.lastIndexOf("/"))+"/";
         return({
              type : "folder",
              name : name,

--- a/solid-ide-solidHandler.js
+++ b/solid-ide-solidHandler.js
@@ -1,5 +1,5 @@
-/* VERSION 0.1.2
-**     2018-11-27
+/* VERSION 0.2.0
+**     2019-02-27
 */
 var SolidHandler = function(){
 
@@ -23,6 +23,11 @@ this.add = async function(parentFolder,newThing,type,content) {
     if(type==='folder') return fc.createFolder(parentFolder+newThing)
     else return fc.createFile(parentFolder+newThing,type,content)
 
+}
+this.cp = function(url,newThing,type) {
+    var filetype;
+    if(type==='folder') return fc.copyFolder(url,newThing)
+    else return fc.copyFile(url,newThing)
 }
 this.get = async function(thing){
     self.qname="";

--- a/solid-ide.js
+++ b/solid-ide.js
@@ -1,5 +1,5 @@
-/* VERSION 0.1.2
-**     2018-11-27
+/* VERSION 0.2.0
+**     2019-02-27
 */
 const fc  = new SolidFileClient()   // from solid-file-client.js
 const sol = new SolidHandler()      // from solid-ide-solidHandler.js
@@ -66,15 +66,45 @@ var app = new Vue({
                return;
             }
             view.hide('folderManager')
+            view.hide('fileManager')
             var name = this.newThing.name
             var url  = this.folder.url
-            sol.add(url,name,type ).then( success => {
+			sol.add(url,name,type ).then( success => {
                 if(success){
                     alert("Resource created: " + name)
                     view.refresh(this.folder.url)
                 }
                 else alert("Couldn't create "+url+" "+sol.err)
             })
+    	},
+        copy : async function(type){
+    	   if(!this.newThing.name){
+           alert("You didn't supply a name!")
+           return;
+            view.hide('folderManager')
+            view.hide('fileManager')
+            }
+        	var name = this.newThing.name
+        	var url = this.folder.url
+        	if (type === 'folder'){
+        		var folder = await fc.readFolder(this.newThing.name);
+        		if(!folder) {alert("The destination folder must exist : \n"+this.newThing.name); return}
+        	}
+        	if (type !== 'folder'){
+        		url = this.file.url;
+        		if (!this.newThing.parentFolder) this.newThing.parentFolder = "";
+        		var name = this.newThing.parentFolder+name;
+	        	var testUrl = this.newThing.parentFolder.split('/');
+	        	if (testUrl[0] !== 'https:') name = this.folder.url+name;
+        	}
+        	if( confirm("COPY RESSOURCE \n"+url+"\n          TO  \n"+name) ){
+        		sol.cp(url,name,type).then(success => {
+        			if(success){
+        				alert("Ressource copied to " + name)
+        			}
+        			else alert(success+"Couldn't copy to "+ name+" "+sol.err)
+        		})
+        	}
         },
         manageResource : function(thing){
             if(!this.perms.Control) return
@@ -362,4 +392,3 @@ var app = new Vue({
     }
 
     init()
-


### PR DESCRIPTION
the main point was to change the `readFile` function to the `body.blob` method in lieu of the `body.txt` one
In the context of solid-ide it works for all files (text and non text including .pdf and image/audio/video.
Could it be the default in solid-file-client. What do you think ?

May be not, but then `readFile in copyFile` should be replaced by a `fetch(url) with blob method` or to add an **optional param in readFile** with default to **txt**.
The advantage of the last option is for education on the body methods.
But this is so complex for me